### PR TITLE
Fixed strict type issues in AbstractClient

### DIFF
--- a/src/Apns/Client/AbstractClient.php
+++ b/src/Apns/Client/AbstractClient.php
@@ -91,12 +91,14 @@ abstract class AbstractClient
             throw new StreamSocketClientException($errstr, $errno, 1, $errfile, $errline);
         });
 
+        $defaultSocketTimeout = ini_get('default_socket_timeout');
+
         try {
             $this->socket = stream_socket_client(
                 $host,
                 $errno,
                 $errstr,
-                ini_get('default_socket_timeout'),
+                $defaultSocketTimeout ? (float)$defaultSocketTimeout : null,
                 STREAM_CLIENT_CONNECT,
                 stream_context_create(
                     [
@@ -124,7 +126,7 @@ abstract class AbstractClient
                 $errstr
             ));
         }
-        stream_set_blocking($this->socket, 0);
+        stream_set_blocking($this->socket, false);
         stream_set_write_buffer($this->socket, 0);
 
         return $this;

--- a/src/Apns/Response/Message.php
+++ b/src/Apns/Response/Message.php
@@ -113,7 +113,7 @@ class Message
             throw new Exception\InvalidArgumentException('Response must be a scalar value');
         }
 
-        if (strlen($rawResponse) === 0) {
+        if ($rawResponse === false || strlen($rawResponse) === 0) {
             $this->code = self::RESULT_OK;
 
             return $this;


### PR DESCRIPTION
`stream_socket_client`'s 4th parameter is supposed to be `float|null` and `stream_set_blocking`'s 2nd parameter is supposed to be `bool`. Due to strict typing (`declare(strict_types=1);`) these were failing before and are fixed now.

`strlen` cannot accept `false`.